### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # genomon_rna_gce
-Perform Genomon RNA pipeline in Google Compute Engine
+
+Perform Genomon RNA pipeline in Google Compute Engine.
+
+# Installation
+
+```sh
+git clone git@github.com:friend1ws/genomon_rna_gce.git
+cd genomon_rna_gce
+pip install . --upgrade
+```
+
+# Quick Start
+
+```sh
+genomon_rna_gce \
+  ./example/sample-conf.tsv \
+  gs://rnaseq_cellline/test171113 \
+  ./example/param.cfg
+```
+
+# Prerequisites
+
+- Python2.7
+- dsub
+- gsutil
+
+And `GOOGLE_APPLICATION_CREDENTIALS` on your machine and JSON file representing the credentials, which is created by `gcloud application-default login`.
+
+See [here](https://developers.google.com/identity/protocols/application-default-credentials) for more information.


### PR DESCRIPTION
When `GOOGLE_APPLICATION_CREDENTIALS` is not specified, or `${HOME}/.config/gcloud/application_default_credentials.json` is not found, the following error must be raised.

```sh
oauth2client.client.ApplicationDefaultCredentialsError: The Application Default Credentials are not available. They are available if running in Google Compute Engine. Otherwise, the environment variable GOOGLE_APPLICATION_CREDENTIALS must be defined pointing to a file defining the credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
```

This is because, as mentioned, `${HOME}/.config/gcloud/application_default_credentials.json` is not existing. Therefore READEM should describe the requirement related to these gcloud authentication stuff.